### PR TITLE
Add interactive logic gate circuit builder

### DIFF
--- a/builder.js
+++ b/builder.js
@@ -1,0 +1,342 @@
+const GATES = [
+  { key:"AND",  name:"AND (И)",   desc:"Выход 1, если все входы = 1", minInputs:2 },
+  { key:"OR",   name:"OR (ИЛИ)",  desc:"Выход 1, если хотя бы один вход = 1", minInputs:2 },
+  { key:"NOT",  name:"NOT (НЕ)",  desc:"Инвертирует единственный вход", minInputs:1, maxInputs:1 },
+  { key:"NAND", name:"NAND",      desc:"Инверсия AND", minInputs:2 },
+  { key:"NOR",  name:"NOR",       desc:"Инверсия OR", minInputs:2 },
+  { key:"XOR",  name:"XOR",       desc:"1 при нечётном числе единиц", minInputs:2 },
+  { key:"XNOR", name:"XNOR",      desc:"Инверсия XOR", minInputs:2 },
+];
+
+const MAX_INPUTS=4;
+
+function evaluateGate(key, inputs){
+  switch(key){
+    case 'AND':  return inputs.every(v=>v===1)?1:0;
+    case 'OR':   return inputs.some(v=>v===1)?1:0;
+    case 'NOT':  return inputs[0]===1?0:1;
+    case 'NAND': return evaluateGate('AND',inputs)^1;
+    case 'NOR':  return evaluateGate('OR',inputs)^1;
+    case 'XOR':  return inputs.reduce((acc,v)=>acc^v,0);
+    case 'XNOR': return evaluateGate('XOR',inputs)^1;
+    default: return 0;
+  }
+}
+
+function createSwitch(initial=0,onToggle){
+  const sw=document.createElement('div');
+  sw.className='switch';
+  sw.dataset.on=initial;
+  const knob=document.createElement('div');
+  knob.className='knob';
+  sw.append(knob);
+  sw.onclick=e=>{
+    e.stopPropagation();
+    sw.dataset.on=sw.dataset.on==='1'?'0':'1';
+    onToggle();
+  };
+  return sw;
+}
+
+function addRow(g){
+  const tr=document.createElement('tr');
+  const td1=document.createElement('td');
+  td1.textContent=g.name;
+  const td2=document.createElement('td');
+  const td3=document.createElement('td');
+  const td4=document.createElement('td');
+  td4.textContent=g.desc;
+
+  const n=g.maxInputs===1?1:2;
+  const switches=[];
+  for(let i=0;i<n;i++){
+    const sw=createSwitch(0,update);
+    td2.append(sw);
+    switches.push(sw);
+  }
+
+  const lamp=document.createElement('span');
+  lamp.className='lamp';
+  td3.append(lamp);
+
+  function update(){
+    const vals=switches.map(sw=>Number(sw.dataset.on));
+    const out=evaluateGate(g.key,vals);
+    lamp.classList.toggle('on',out===1);
+  }
+
+  update();
+  tr.append(td1,td2,td3,td4);
+  document.getElementById('tbody').append(tr);
+}
+
+GATES.forEach(addRow);
+
+// === Circuit builder ===
+const nodes=[];
+const connections=[];
+let nextId=1;
+let selectedType=null;
+let pending=null;
+let ghost=null;
+let ghostWire=null;
+
+const palette=document.getElementById('palette');
+const workspace=document.getElementById('workspace');
+const wires=document.getElementById('wires');
+const buttons=[];
+
+const types=['INPUT','OUTPUT','DELETE',...GATES.map(g=>g.key)];
+types.forEach(t=>{
+  const b=document.createElement('button');
+  b.textContent=t;
+  b.dataset.type=t;
+  b.onclick=()=>selectType(t);
+  palette.append(b);
+  buttons.push(b);
+});
+
+function selectType(t){
+  selectedType=t;
+  buttons.forEach(b=>b.classList.toggle('active',b.dataset.type===t));
+  if(ghost){ghost.remove();ghost=null;}
+  if(t && t!=='DELETE'){
+    ghost=document.createElement('div');
+    ghost.className='node ghost';
+    const label=document.createElement('span');
+    label.textContent=t;
+    ghost.append(label);
+    workspace.append(ghost);
+  }
+}
+
+workspace.addEventListener('mousemove',e=>{
+  if(ghost){
+    const rect=workspace.getBoundingClientRect();
+    ghost.style.left=e.clientX-rect.left+'px';
+    ghost.style.top=e.clientY-rect.top+'px';
+  }
+  if(pending) updateGhostWire(e);
+});
+
+workspace.addEventListener('click',e=>{
+  const rect=workspace.getBoundingClientRect();
+  if(selectedType && selectedType!=='DELETE'){
+    createNode(selectedType,e.clientX-rect.left,e.clientY-rect.top);
+    selectType(null);
+  }else if(selectedType==='DELETE'){
+    selectType(null);
+  }else if(pending){
+    cancelPending();
+  }
+});
+
+function createPort(node,kind,index){
+  const el=document.createElement('div');
+  el.className='port '+kind;
+  el.dataset.nodeId=node.id;
+  el.dataset.kind=kind;
+  el.dataset.index=index;
+  el.addEventListener('click',portClicked);
+  return {node,kind,index,el,connections:[]};
+}
+
+function createNode(type,x,y){
+  const n={id:nextId++,type,x,y,inputs:[],output:null,state:0};
+  const el=document.createElement('div');
+  el.className='node';
+  el.style.left=x+'px';
+  el.style.top=y+'px';
+  el.addEventListener('click',e=>{
+    e.stopPropagation();
+    if(selectedType==='DELETE') removeNode(n);
+  });
+  el.addEventListener('mousedown',e=>startDrag(n,e));
+  n.el=el;
+  if(type==='INPUT'){
+    const sw=createSwitch(0,()=>{n.state=Number(sw.dataset.on);evaluate();});
+    el.append(sw);n.state=0;
+    n.output=createPort(n,'out',0);el.append(n.output.el);
+  }else if(type==='OUTPUT'){
+    const p=createPort(n,'in',0);n.inputs.push(p);el.append(p.el);
+    const lamp=document.createElement('span');lamp.className='lamp';lamp.style.marginLeft='20px';el.append(lamp);n.lamp=lamp;
+  }else{
+    const gate=GATES.find(g=>g.key===type);n.gate=gate;
+    const cnt=gate.maxInputs===1?1:gate.minInputs;
+    for(let i=0;i<cnt;i++){const p=createPort(n,'in',i);n.inputs.push(p);el.append(p.el);}    
+    n.output=createPort(n,'out',0);el.append(n.output.el);
+    const label=document.createElement('span');label.textContent=type;el.append(label);
+    if(gate.maxInputs!==1){
+      const add=document.createElement('button');add.textContent='+';add.className='small add-input';add.onclick=e=>{e.stopPropagation();addInput(n);};
+      const sub=document.createElement('button');sub.textContent='-';sub.className='small remove-input';sub.onclick=e=>{e.stopPropagation();removeInput(n);};
+      el.append(add,sub);
+    }
+  }
+  layoutPorts(n);
+  workspace.append(el);nodes.push(n);evaluate();
+}
+
+function layoutPorts(n){
+  const h=n.el.clientHeight;
+  if(n.type==='INPUT'){
+    n.output.el.style.top=(h/2-6)+'px';
+  }else if(n.type==='OUTPUT'){
+    n.inputs[0].el.style.top=(h/2-6)+'px';
+  }else{
+    const cnt=n.inputs.length;
+    const gap=h/(cnt+1);
+    n.inputs.forEach((p,i)=>{
+      p.index=i;
+      p.el.dataset.index=i;
+      p.el.style.top=(gap*(i+1)-6)+'px';
+    });
+    n.output.el.style.top=(h/2-6)+'px';
+  }
+}
+
+function addInput(n){
+  const max=n.gate.maxInputs||MAX_INPUTS;
+  if(n.inputs.length>=max) return;
+  const p=createPort(n,'in',n.inputs.length);
+  n.inputs.push(p);n.el.append(p.el);
+  layoutPorts(n);evaluate();
+}
+
+function removeInput(n){
+  if(n.inputs.length<=n.gate.minInputs) return;
+  const p=n.inputs.pop();
+  p.connections.slice().forEach(removeConnection);
+  n.el.removeChild(p.el);
+  layoutPorts(n);evaluate();
+}
+
+function removeNode(n){
+  [...n.inputs, n.output].filter(Boolean).forEach(p=>p.connections.slice().forEach(removeConnection));
+  workspace.removeChild(n.el);
+  nodes.splice(nodes.indexOf(n),1);
+  evaluate();
+}
+
+let dragging=null,dragOffset=null;
+function startDrag(n,e){
+  if(selectedType||pending) return;
+  if(e.target.classList.contains('port')||e.target.closest('.switch')||e.target.tagName==='BUTTON') return;
+  dragging=n;
+  const r=n.el.getBoundingClientRect();
+  const ws=workspace.getBoundingClientRect();
+  dragOffset={x:e.clientX-r.left,y:e.clientY-r.top,wsx:ws.left,wsy:ws.top};
+  document.addEventListener('mousemove',onDrag);
+  document.addEventListener('mouseup',endDrag);
+}
+
+function onDrag(e){
+  if(!dragging) return;
+  const x=e.clientX-dragOffset.wsx-dragOffset.x;
+  const y=e.clientY-dragOffset.wsy-dragOffset.y;
+  dragging.x=x;dragging.y=y;
+  dragging.el.style.left=x+'px';
+  dragging.el.style.top=y+'px';
+  evaluate();
+}
+
+function endDrag(){
+  dragging=null;dragOffset=null;
+  document.removeEventListener('mousemove',onDrag);
+  document.removeEventListener('mouseup',endDrag);
+}
+
+function portClicked(ev){
+  ev.stopPropagation();
+  if(selectedType==='DELETE'){
+    const node=nodes.find(n=>n.id==ev.currentTarget.dataset.nodeId);
+    removeNode(node);
+    return;
+  }
+  if(selectedType) selectType(null);
+  const el=ev.currentTarget;
+  const node=nodes.find(n=>n.id==el.dataset.nodeId);
+  const port=(el.dataset.kind==='in'?node.inputs:[node.output])[el.dataset.index];
+  if(!pending){
+    if(port.kind==='out') startPending(port);
+  }else{
+    if(port.kind==='in'&&port!==pending.from){
+      connect(pending.from,port);
+    }
+    cancelPending();
+  }
+}
+
+function startPending(from){
+  pending={from};
+  ghostWire=document.createElementNS('http://www.w3.org/2000/svg','line');
+  ghostWire.classList.add('wire','ghost-wire');
+  wires.append(ghostWire);
+  const a=getPortCenter(from);
+  ghostWire.setAttribute('x1',a.x);ghostWire.setAttribute('y1',a.y);
+  ghostWire.setAttribute('x2',a.x);ghostWire.setAttribute('y2',a.y);
+}
+
+function updateGhostWire(e){
+  if(!ghostWire) return;
+  const a=getPortCenter(pending.from);
+  const rect=workspace.getBoundingClientRect();
+  ghostWire.setAttribute('x1',a.x);
+  ghostWire.setAttribute('y1',a.y);
+  ghostWire.setAttribute('x2',e.clientX-rect.left);
+  ghostWire.setAttribute('y2',e.clientY-rect.top);
+}
+
+function cancelPending(){
+  pending=null;
+  if(ghostWire){wires.removeChild(ghostWire);ghostWire=null;}
+}
+
+function connect(from,to){
+  const line=document.createElementNS('http://www.w3.org/2000/svg','line');
+  line.classList.add('wire');
+  wires.append(line);
+  const c={from,to,line};
+  from.connections.push(c);to.connections.push(c);connections.push(c);
+  evaluate();
+}
+
+function removeConnection(c){
+  c.from.connections=c.from.connections.filter(x=>x!==c);
+  c.to.connections=[];
+  wires.removeChild(c.line);
+  connections.splice(connections.indexOf(c),1);
+}
+
+function getPortCenter(p){
+  const ws=workspace.getBoundingClientRect();
+  const r=p.el.getBoundingClientRect();
+  return {x:r.left-ws.left+r.width/2,y:r.top-ws.top+r.height/2};
+}
+
+function updateLine(c){
+  const a=getPortCenter(c.from),b=getPortCenter(c.to);
+  c.line.setAttribute('x1',a.x);c.line.setAttribute('y1',a.y);
+  c.line.setAttribute('x2',b.x);c.line.setAttribute('y2',b.y);
+}
+
+function getInputValue(p,vis){
+  if(!p.connections.length)return 0;
+  return evaluateNode(p.connections[0].from.node,vis);
+}
+
+function evaluateNode(n,vis){
+  if(vis.has(n))return n.value;
+  vis.add(n);
+  if(n.type==='INPUT'){n.value=n.state;return n.value;}
+  if(n.type==='OUTPUT'){
+    const v=getInputValue(n.inputs[0],vis);n.value=v;n.lamp.classList.toggle('on',v===1);return v;
+  }
+  const vals=n.inputs.map(p=>getInputValue(p,vis));n.value=evaluateGate(n.type,vals);return n.value;
+}
+
+function evaluate(){
+  connections.forEach(updateLine);
+  const vis=new Set();
+  nodes.forEach(n=>evaluateNode(n,vis));
+  connections.forEach(c=>{c.line.classList.toggle('on',c.from.node.value===1);});
+}

--- a/docs/builder.md
+++ b/docs/builder.md
@@ -1,0 +1,14 @@
+# Logic Gate Builder
+
+A simple in-browser environment for assembling logic circuits.
+
+- **Palette**: choose between `INPUT`, `OUTPUT` and gates `AND`, `OR`, `NOT`, `NAND`, `NOR`, `XOR`, `XNOR`.
+- **Workspace**: click to place the selected component. A translucent ghost previews placement.
+- **Connections**: click an output port then an input port to draw a wire. Wires carrying a signal glow red. While linking, a ghost line follows the cursor.
+- **Simulation**: toggle an `INPUT` switch to send a signal. Outputs show a green lamp when they receive a signal through the circuit.
+- **Auto-deselect**: after placing a component or completing a wire, the selection clears to prevent accidental extra placements.
+- **Drag & drop**: move any placed block by dragging it around the workspace.
+- **Delete**: select `DELETE` in the palette and click a block to remove it along with attached wires.
+- **Variable inputs**: gates (except `NOT`) have `+` and `-` buttons to adjust their number of input ports.
+
+Use this environment for quick experiments with logic gates directly in the browser.

--- a/index.html
+++ b/index.html
@@ -4,20 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Логические гейты — таблица</title>
-  <style>
-    body{background:#0f1220;color:#e9ecff;font-family:system-ui,sans-serif;margin:0;padding:20px}
-    h1{margin-bottom:20px}
-    table{width:100%;border-collapse:collapse;background:#171a2b;border:1px solid #2a3154}
-    th,td{border:1px solid #2a3154;padding:12px;text-align:center}
-    th{background:#1f233a}
-    tr{height:70px}
-    .switch{cursor:pointer;display:inline-block;width:60px;height:28px;background:#232848;border-radius:14px;position:relative;margin:0 4px}
-    .switch[data-on="1"]{background:#41d873}
-    .switch .knob{position:absolute;top:3px;left:3px;width:22px;height:22px;background:white;border-radius:50%;transition:0.2s}
-    .switch[data-on="1"] .knob{left:35px}
-    .lamp{width:22px;height:22px;border-radius:50%;display:inline-block;background:#2a2f52;margin-left:8px}
-    .lamp.on{background:#41d873}
-  </style>
+  <link rel="stylesheet" href="style.css" />
 </head>
 <body>
   <h1>Таблица логических гейтов</h1>
@@ -33,77 +20,13 @@
     <tbody id="tbody"></tbody>
   </table>
 
-  <script>
-    const GATES = [
-      { key:"AND",  name:"AND (И)",   desc:"Выход 1, если все входы = 1", minInputs:2 },
-      { key:"OR",   name:"OR (ИЛИ)",  desc:"Выход 1, если хотя бы один вход = 1", minInputs:2 },
-      { key:"NOT",  name:"NOT (НЕ)",  desc:"Инвертирует единственный вход", minInputs:1, maxInputs:1 },
-      { key:"NAND", name:"NAND",      desc:"Инверсия AND", minInputs:2 },
-      { key:"NOR",  name:"NOR",       desc:"Инверсия OR", minInputs:2 },
-      { key:"XOR",  name:"XOR",       desc:"1 при нечётном числе единиц", minInputs:2 },
-      { key:"XNOR", name:"XNOR",      desc:"Инверсия XOR", minInputs:2 },
-    ];
+  <div id="builder">
+    <div id="palette"></div>
+    <div id="workspace">
+      <svg id="wires"></svg>
+    </div>
+  </div>
 
-    function evaluateGate(key, inputs){
-      switch(key){
-        case 'AND':  return inputs.every(v=>v===1)?1:0;
-        case 'OR':   return inputs.some(v=>v===1)?1:0;
-        case 'NOT':  return inputs[0]===1?0:1;
-        case 'NAND': return evaluateGate('AND',inputs)^1;
-        case 'NOR':  return evaluateGate('OR',inputs)^1;
-        case 'XOR':  return inputs.reduce((acc,v)=>acc^v,0);
-        case 'XNOR': return evaluateGate('XOR',inputs)^1;
-        default: return 0;
-      }
-    }
-
-    function createSwitch(initial=0,onToggle){
-      const sw=document.createElement('div');
-      sw.className='switch';
-      sw.dataset.on=initial;
-      const knob=document.createElement('div');
-      knob.className='knob';
-      sw.append(knob);
-      sw.onclick=()=>{
-        sw.dataset.on=sw.dataset.on==='1'?'0':'1';
-        onToggle();
-      };
-      return sw;
-    }
-
-    function addRow(g){
-      const tr=document.createElement('tr');
-      const td1=document.createElement('td');
-      td1.textContent=g.name;
-      const td2=document.createElement('td');
-      const td3=document.createElement('td');
-      const td4=document.createElement('td');
-      td4.textContent=g.desc;
-
-      const n=g.maxInputs===1?1:2;
-      const switches=[];
-      for(let i=0;i<n;i++){
-        const sw=createSwitch(0,update);
-        td2.append(sw);
-        switches.push(sw);
-      }
-
-      const lamp=document.createElement('span');
-      lamp.className='lamp';
-      td3.append(lamp);
-
-      function update(){
-        const vals=switches.map(sw=>Number(sw.dataset.on));
-        const out=evaluateGate(g.key,vals);
-        lamp.classList.toggle('on',out===1);
-      }
-
-      update();
-      tr.append(td1,td2,td3,td4);
-      document.getElementById('tbody').append(tr);
-    }
-
-    GATES.forEach(addRow);
-  </script>
+  <script src="builder.js"></script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,30 @@
+body{background:#0f1220;color:#e9ecff;font-family:system-ui,sans-serif;margin:0;padding:20px}
+h1{margin-bottom:20px}
+table{width:100%;border-collapse:collapse;background:#171a2b;border:1px solid #2a3154}
+th,td{border:1px solid #2a3154;padding:12px;text-align:center}
+th{background:#1f233a}
+tr{height:70px}
+.switch{cursor:pointer;display:inline-block;width:60px;height:28px;background:#232848;border-radius:14px;position:relative;margin:0 4px}
+.switch[data-on="1"]{background:#41d873}
+.switch .knob{position:absolute;top:3px;left:3px;width:22px;height:22px;background:white;border-radius:50%;transition:0.2s}
+.switch[data-on="1"] .knob{left:35px}
+.lamp{width:22px;height:22px;border-radius:50%;display:inline-block;background:#2a2f52;margin-left:8px}
+.lamp.on{background:#41d873}
+
+#builder{margin-top:40px;display:flex;gap:20px}
+#palette{width:160px}
+#palette button{width:100%;margin-bottom:6px;padding:6px;background:#232848;color:#e9ecff;border:1px solid #2a3154;cursor:pointer}
+#palette button.active{outline:2px solid #41d873}
+#workspace{position:relative;flex:1;height:400px;background:#171a2b;border:1px solid #2a3154}
+#wires{position:absolute;top:0;left:0;width:100%;height:100%;pointer-events:none}
+.wire{stroke:#2a3154;stroke-width:2}
+.wire.on{stroke:red}
+.wire.ghost-wire{stroke:#888;stroke-dasharray:4 2}
+.node{position:absolute;background:#1f233a;border:1px solid #2a3154;border-radius:4px;color:#e9ecff;font-size:14px;width:80px;height:60px;display:flex;align-items:center;justify-content:center}
+.node.ghost{opacity:.5;pointer-events:none}
+.node button.small{position:absolute;width:16px;height:16px;padding:0;font-size:12px}
+.node button.add-input{top:2px;right:2px}
+.node button.remove-input{top:2px;right:20px}
+.port{width:12px;height:12px;border-radius:50%;background:#444;position:absolute;cursor:pointer}
+.port.in{left:-6px}
+.port.out{right:-6px}


### PR DESCRIPTION
## Summary
- break out inline styles/scripts into dedicated files for easier maintenance
- preview gate and wire placement with translucent ghosts and auto-clear selection after placing
- document the builder workflow and new previews
- enlarge gates with symmetric ports, add dragging, deletion tool and configurable input counts

## Testing
- `npx -y htmlhint index.html`
- `node -c builder.js`


------
https://chatgpt.com/codex/tasks/task_e_68bfbe9a45b48326bf4ffb0a63faa15e